### PR TITLE
Release candidate v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Configurable options, shown here with defaults:
 :sidekiq_log => File.join(shared_path, 'log', 'sidekiq.log')
 
 # sidekiq systemd options
+:sidekiq_service_templates_path => 'config/deploy/templates' # to be used if a custom template is needed (filaname should be #{fetch(:sidekiq_service_unit_name)}.service.capistrano.erb or sidekiq.service.capistrano.erb
 :sidekiq_service_unit_name => 'sidekiq'
 :sidekiq_service_unit_user => :user # :system
 :sidekiq_enable_lingering => true

--- a/lib/capistrano/sidekiq/systemd.rb
+++ b/lib/capistrano/sidekiq/systemd.rb
@@ -5,6 +5,7 @@ module Capistrano
       set_if_empty :sidekiq_service_unit_user, :user # :system
       set_if_empty :sidekiq_enable_lingering, true
       set_if_empty :sidekiq_lingering_user, nil
+      set_if_empty :sidekiq_service_templates_path, 'config/deploy/templates'
     end
 
     def define_tasks

--- a/lib/capistrano/sidekiq/version.rb
+++ b/lib/capistrano/sidekiq/version.rb
@@ -1,3 +1,3 @@
 module Capistrano
-  SidekiqVERSION = '2.0.0'
+  SidekiqVERSION = '2.1.0'
 end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -87,7 +87,10 @@ namespace :sidekiq do
   end
 
   def compiled_template
+    local_template_directory = fetch(:sidekiq_service_templates_path)
     search_paths = [
+      File.join(local_template_directory, "#{fetch(:sidekiq_service_unit_name)}.service.capistrano.erb"),
+      File.join(local_template_directory, 'sidekiq.service.capistrano.erb'),
       File.expand_path(
           File.join(*%w[.. .. .. generators capistrano sidekiq systemd templates sidekiq.service.capistrano.erb]),
           __FILE__

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -113,10 +113,10 @@ namespace :sidekiq do
         "/tmp/#{fetch :sidekiq_service_unit_name}.service"
     )
     if fetch(:sidekiq_service_unit_user) == :system
-      backend.execute :sudo, :mv, "/tmp/#{fetch :sidekiq_service_unit_name}.service", "#{systemd_path}/#{fetch :sidekiq_service_unit_name}.service"
+      backend.execute :sudo, :mv, "/tmp/#{fetch :sidekiq_service_unit_name}.service", "#{systemd_path}#{fetch :sidekiq_service_unit_name}.service"
       backend.execute :sudo, :systemctl, "daemon-reload"
     else
-      backend.execute :mv, "/tmp/#{fetch :sidekiq_service_unit_name}.service", "#{systemd_path}/#{fetch :sidekiq_service_unit_name}.service"
+      backend.execute :mv, "/tmp/#{fetch :sidekiq_service_unit_name}.service", "#{systemd_path}#{fetch :sidekiq_service_unit_name}.service"
       backend.execute :systemctl, "--user", "daemon-reload"
     end
   end


### PR DESCRIPTION
This pull request will not be merged in, this branch was used to create the 'v2.1.0' tag which our applications are using for systemd templating. Anyone wanting to customise their systemd templating should tag v2.1.0 until it becomes available in the main community repository. 

-------

The main community repository at https://github.com/seuros/capistrano-sidekiq supports custom template path in master, however it has not been released to a stable version yet.

This will tie us over until a stable version has been released with what we need.

Commit hash from: seuros@4fd530f.

Also some aesthetic changes. 